### PR TITLE
add mandatory variables

### DIFF
--- a/cc_plugin_og/checker.py
+++ b/cc_plugin_og/checker.py
@@ -7,7 +7,7 @@ from cc_plugin_og import OGChecker
 class OGChecker(OGChecker):
     _cc_spec_version = "1.0"
     _cc_description = f"og {_cc_spec_version} compliance-checker"
-    _cc_display_headers = {3: "Highly Recommended", 2: "Recommended", 1: "Suggested"}
+    _cc_display_headers = {3: "Mandatory", 2: "Highly Recommended", 1: "Suggested"}
 
     METHODS_REGEX = re.compile(r"(\w+: *\w+) \((\w+: *\w+)\) *")
     PADDING_TYPES = ["none", "low", "high", "both"]
@@ -15,28 +15,39 @@ class OGChecker(OGChecker):
     def __init__(self):
         pass
 
-    def check_basic_requirements(self, dataset):
+    def check_mandatory_variables(self, dataset):
         """
         Check check_basic_requirements()
         """
 
         level = BaseCheck.HIGH
         score = 0
-        out_of = 1
         messages = []
         desc = "This checks basic requirements."
 
-        # Do test things here
-        ans = 0
+        required_variables = [
+            "LATITUDE_GPS",
+            "LONGITUDE_GPS",
+            "TIME_GPS",
+            "LATITUDE",
+            "LONGITUDE",
+            "TIME",
+            "TRAJECTORY",
+            "PLATFORM_MODEL",
+            "WMO_IDENTIFIER",
+            "PLATFORM_SERIAL_NUMBER",
+            "DEPLOYMENT_TIME",
+            "DEPLOYMENT_LATITUDE",
+            "DEPLOYMENT_LONGITUDE",
+        ]
 
-        try:
-            assert ans == 0
-        except AssertionError:
-            # Many messages may be appended here
-            m = '... test failed.'
-            messages.append(m)
-        else:
-            score += 1
+        out_of = len(required_variables)
+        for variable in required_variables:
+            try:
+                assert variable in dataset.variables
+            except AssertionError:
+                score += 1
+                messages.append(f"Variable {variable} is missing")
 
         return self.make_result(level, score, out_of, desc, messages)
 


### PR DESCRIPTION
This PR adds a check for the mandatory variables. It also sets the three levels of severity to  `{3: "Mandatory", 2: "Highly Recommended", 1: "Suggested"}` as they are in OG1.0